### PR TITLE
Bug 2050466: Not allow "" string in registriesConf entry

### DIFF
--- a/pkg/registries/registries.go
+++ b/pkg/registries/registries.go
@@ -221,6 +221,9 @@ func EditRegistriesConfig(config *sysregistriesv2.V2RegistriesConf, insecureScop
 // This function can be used to validate the registries entries prior to calling EditRegistriesConfig
 // in the MCO or builds code
 func IsValidRegistriesConfScope(scope string) bool {
+	if scope == "" {
+		return false
+	}
 	// If scope does not contain the wildcard character, we will assume it is a regular registry entry, which is valid
 	if !strings.Contains(scope, "*") {
 		return true

--- a/pkg/registries/registries_test.go
+++ b/pkg/registries/registries_test.go
@@ -69,6 +69,7 @@ func TestIsValidRegistriesConfScope(t *testing.T) {
 		{"*example.com", false},
 		{"*/example.com", false},
 		{"*.*example.com", false},
+		{"", false}, // Invalid empty string entry
 	} {
 		t.Run(fmt.Sprintf("%#v", tt.scope), func(t *testing.T) {
 			res := IsValidRegistriesConfScope(tt.scope)


### PR DESCRIPTION
Fix: https://bugzilla.redhat.com/show_bug.cgi?id=2050466
Add validation to not allow empty string ("") if get it from Image and ICSP CRD.
Empty string regsitries configurations will fail the machine config daemon operations
of pulling images and the nodes will stopped in NotReady state when node rebooting after node drain.
```
2022-02-03T23:16:02.952318066Z I0203 23:16:02.952259    2590 run.go:18] Running: podman pull -q --authfile /var/lib/kubelet/config.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:6d4ff6bb5494c55c24f9a322b1a5faffb8a92ea0f572f1078db55f3f1abaa588
2022-02-03T23:16:03.033231339Z Error: error loading registries configuration "/etc/containers/registries.conf": invalid condition: mirror location is unset

```

Signed-off-by: Qi Wang <qiwan@redhat.com>